### PR TITLE
Detect serverRoot and emit values for child configs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,11 +11,21 @@ Apacheconf is an apache config file parser for Node.js.
 
     var apacheconf = require('apacheconf')
 
-    apacheconf('/etc/apache2/httpd.conf', function(err, config, parser) {
+    const parser = apacheconf('/etc/apache2/httpd.conf', function(err, config, parser) {
       if (err) throw err
 
       console.log(config)
     })
+```
+
+You can also listen for events when config values are found (with keys).
+
+```js
+// Any value
+parser.on('emit', function (key, value) {})
+
+// Desired value
+parser.on('VirtualHost', function (value) {})
 ```
 
 
@@ -23,6 +33,11 @@ Apacheconf is an apache config file parser for Node.js.
 
     npm install apacheconf
 
+
+## Server root
+
+- Server root will be automatically detected based on file location (uses dirname): `/etc/apache2/httpd.conf` > `/etc/apache2/`.
+- If config contains `ServerRoot` settings, the path from config will be used.
 
 ## Licence
 

--- a/index.js
+++ b/index.js
@@ -248,9 +248,9 @@ Parser.prototype.emitValue = function (name, value) {
 
 Parser.prototype._getProp = function(prop) {
   var that = this
-  while(!(prop in that) && that._parent) {
-    that = that._parent
-  }
+    if (typeof that[prop] === 'undefined' && that._parent) {
+      that = that._parent;
+    }
   return that[prop]
 }
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "event-stream": "~3.0.2",
-    "glob": "~3.2.1",
-    "debug": "~0.7.2"
+    "glob": "~7.1.3",
+    "debug": "~4.0.1"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
- Detect root based on dirname of the file or by ServerRoot settings in config
- Emit events on parent for every child (we need to listen for any value found in config)
- Include also optional configs: IncludeOption