### PR TITLE
fix "Cannot call method resume of undefined error"

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ Parser.prototype.write = function(line) {
       , self = this
     this._child = child
     child._parent = this
+    child._stream = this._stream
+    child.file = this.file
 
     function onerror(err) {
       self.emit('error', err)


### PR DESCRIPTION
This error occurs when the parser follows the "Include" directive and then tries to resume stream by accessing `this._stream` on what is actually a child-stream.